### PR TITLE
refactor: Fix category and article list pages

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -76,7 +76,7 @@ class ArticleController extends Controller
     {
         return view('layouts/categoryUncategorized')
                 ->with([
-                    'articles' => Article::doesntHave('categories')->with('categories')->orderBy('updated_at', 'desc')->Paginate(10),
+                    'articles' => Article::doesntHave('categories')->orderBy('updated_at', 'desc')->Paginate(10),
                     'categoryList' => $this->getValidCategories()
                 ]);
     }

--- a/resources/views/layouts/category.blade.php
+++ b/resources/views/layouts/category.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('content')
-    @foreach ($articles->getCOllection() as $article)
+    @foreach ($articles->getCollection() as $article)
         <article class="article">
             <a href="{{route('article.show', $article->id)}}">
                 <p>

--- a/resources/views/layouts/categoryUncategorized.blade.php
+++ b/resources/views/layouts/categoryUncategorized.blade.php
@@ -1,11 +1,11 @@
 @extends('layouts.app')
 
 @section('headerCategory')
-    <h1>カテゴリー：{{$category->label}}</h1>
+    <h1>カテゴリー：未分類</h1>
 @endsection
 
 @section('content')
-    @foreach ($articles->getCOllection() as $article)
+    @foreach ($articles->getCollection() as $article)
         <article class="article">
             <a href="{{route('article.show', $article->id)}}">
                 <p>
@@ -17,9 +17,7 @@
                 </p>
                 <h3>{{$article->title}}</h3>
                 <p>{{$article->content}}</p>
-                @if(count($article->categories) > 0)
-                    <p>この記事のカテゴリー：{{$article->categories->implode('label')}}</p>
-                @endif
+                <p>この記事のカテゴリー：未分類</p>
             </a>
         </article>
     @endforeach
@@ -27,22 +25,22 @@
 @endsection
 
 @section('categoryMenuCategory')
-<div class="categoriesSelect">
-    <ul>
-        <li>
-            記事選択
-        </li>
-        <li>
-            <a href="{{route('index')}}">全件表示</a>
-        </li>
-        @foreach($categoryList as $category)
+    <div class="categoriesSelect">
+        <ul>
             <li>
-                <a href="{{route('article.category', $category->id)}}">{{$category->label}}</a>
+                記事選択
             </li>
-        @endforeach
-        <li>
-            <a href="{{route('article.category.uncategorized')}}">未分類</a>
-        </li>
-    </ul>
-</div>
+            <li>
+                <a href="{{route('index')}}">全件表示</a>
+            </li>
+            @foreach($categoryList as $category)
+                <li>
+                    <a href="{{route('article.category', $category->id)}}">{{$category->label}}</a>
+                </li>
+            @endforeach
+            <li>
+                <a href="{{route('article.category.uncategorized')}}">未分類</a>
+            </li>
+        </ul>
+    </div>
 @endsection

--- a/resources/views/layouts/index.blade.php
+++ b/resources/views/layouts/index.blade.php
@@ -20,9 +20,11 @@
                 </p>
                 <h3>{{$article->title}}</h3>
                 <p>{{$article->content}}</p>
-                @foreach ($article->categories as $category)
-                    <p>この記事のカテゴリー：{{$category->label}}</p>
-                @endforeach
+                @if(count($article->categories) > 0)
+                    <p>この記事のカテゴリー：{{$article->categories->implode('label')}}</p>
+                @else
+                    <p>この記事のカテゴリー：未分類</p>
+                @endif
             </a>
         </article>
     @endforeach
@@ -42,7 +44,7 @@
                 <li><a href="{{route('article.category', $category->id)}}">{{$category->label}}</a></li>
             @endforeach
             <li>
-                未分類
+                <a href="{{route('article.category.uncategorized')}}">未分類</a>
             </li>
         </ul>
     </div>

--- a/resources/views/layouts/show.blade.php
+++ b/resources/views/layouts/show.blade.php
@@ -9,10 +9,9 @@
 
 @section('content')
     <p>{{$article->content}}</p>
-    <?php $categoryLabels = $article->categories->pluck( 'label' ) ?>
-    <?php if (!empty($categoryLabels)){  ?>
-    <p>この記事のカテゴリー：{{$article->categories->implode('label')}}</p>
-    <?php }?>
+    @if(count($article->categories) > 0)
+        <p>この記事のカテゴリー：{{$article->categories->implode('label')}}</p>
+    @endif
     <ul id="blog-menu">
         <li>
             <a href="{{route('index')}}" class="btn">戻る</a>
@@ -30,10 +29,12 @@
                 <a href="{{route('index')}}">全件表示</a>
             </li>
             @foreach($categories as $category)
-                <li><a href="{{route('article.category', $category->id)}}">{{$category->label}}</a></li>
+                <li>
+                    <a href="{{route('article.category', $category->id)}}">{{$category->label}}</a>
+                </li>
             @endforeach
             <li>
-                未分類
+                <a href="{{route('article.category.uncategorized')}}">未分類</a>
             </li>
         </ul>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Auth;
 Route::controller(ArticleController::class)->group(function() {
     Route::get('/index', 'index')->name('index');
     Route::get('/index/article/{id}', 'show')->name('article.show');
+    Route::get('/index/category/uncategorized', 'showUncategorized')->name('article.category.uncategorized');
     Route::get('/index/category/{id}', 'category')->name('article.category');
 });
 


### PR DESCRIPTION
## 概要
方向性が怪しかったのでがっつり修正をした。
全体の画面で挙動が統一されていない箇所についてはバグとみなして修正した。

先にこのPRを 7-カテゴリ別記事一覧のブランチにマージする必要があるので注意。
## 変更点
- 記事一覧ではカテゴリモデル経由の記事モデルではなく、記事(Article)モデルを返却するように変更
- サイドバーのカテゴリについて、1件以上の記事にリレーションされている項目のみを表示するようにした
   (記事がないリンクができてしまうため）
- ページネーションがカテゴリ個別ページになかったので追加
- 未分類の場合の考慮が漏れていたので追加
- 記事のリンクがカテゴリ以降ページで抜けていたので追加
- その他Code Styleの修正

## SS
<img width="1436" alt="スクリーンショット 2023-01-09 15 36 57" src="https://user-images.githubusercontent.com/49839611/211252711-9ee6ffbe-c1ea-4d67-879c-5582fde3ed36.png">

<img width="1436" alt="スクリーンショット 2023-01-09 15 37 26" src="https://user-images.githubusercontent.com/49839611/211252715-2a3778e5-e225-4bfd-933b-79d278e7a197.png">
##
<img width="1436" alt="スクリーンショット 2023-01-09 15 38 51" src="https://user-images.githubusercontent.com/49839611/211252718-bd4a0adf-d1d1-43c1-b079-4de69d36e5b4.png">
